### PR TITLE
Project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,20 @@ homepage = "https://investos.io/"
 repository = "https://github.com/charliereese/investos"
 documentation = "https://investos.readthedocs.io/en/latest/"
 keywords = ["investing", "alpha", "backtesting", "portfolio", "optimization"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: Other/Proprietary License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.9",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Topic :: Software Development :: Testing",
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ packages = [{include = "investos"}]
 homepage = "https://investos.io/"
 repository = "https://github.com/charliereese/investos"
 documentation = "https://investos.readthedocs.io/en/latest/"
+keywords = ["investing", "alpha", "backtesting", "portfolio", "optimization"]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
* Add keywords for PyPI listing (5332c6f)

* Add Trove classifiers (d4c1bbd)

    Went over https://pypi.org/classifiers/ and picked what seemed relevant.

Cherry-picked from #1 

----

Classifiers will show up in PyPI like this (using numpy as an example). They're a quick discoverability and documentation win.

<img width="1389" alt="Screen Shot 2023-07-16 at 8 52 14 PM" src="https://github.com/charliereese/investos/assets/4542383/15ea3e5a-a49f-4bd4-aa15-60c29efa73b1">

