### PR TITLE
Use quote markdown for blog quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **InvestOS** (/InvEst əʊˈes/) is a Python library for investors who want to focus on generating alpha. As it stands today, it provides reliable backtesting and portfolio optimization software for investors... but we have bigger ambitions!
 
-As mentioned in our [first blog article](https://blog.investos.io/why-we-created-investos/): _“From the start, our goal has been to support all possible optimization strategies and backtesting requirements through flexible, extensible code, while prioritizing reliability and ease-of-use. Once we feel we’ve achieved that goal as it pertains to portfolio optimization and backtesting, we plan to begin productizing other (non-IP) parts of investors’ alpha-generation process.”_
+As mentioned in our [first blog article](https://blog.investos.io/why-we-created-investos/):
+
+> From the start, our goal has been to support all possible optimization strategies and backtesting requirements through flexible, extensible code, while prioritizing reliability and ease-of-use.
+> Once we feel we’ve achieved that goal as it pertains to portfolio optimization and backtesting, we plan to begin productizing other (non-IP) parts of investors’ alpha-generation process.
 
 For more information, visit [investos.io](https://investos.io).


### PR DESCRIPTION
Cherry-picked from https://github.com/charliereese/investos/pull/1

Looks nicer, and more semantically accurate than using italics. Will also play with docs generation tool more nicely (e.g. custom format for quotes, etc.)

## Before

<img width="857" alt="Screen Shot 2023-07-16 at 8 56 20 PM" src="https://github.com/charliereese/investos/assets/4542383/84fe7cf1-a110-4c87-bb9e-42e412c7c9d1">

## After

<img width="997" alt="Screen Shot 2023-07-16 at 8 56 28 PM" src="https://github.com/charliereese/investos/assets/4542383/d27f9c07-c98e-4e98-a38d-02810b8f5f14">
