### PR TITLE
Black pre-commit and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/psf/black
+    rev: '23.7.0'
+    hooks:
+      - id: black-jupyter
+        description: Check the code and notebooks have been formatted with Black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,27 @@ To reformat the codebase, run:
 poetry run black .
 ```
 
+You can use [pre-commit hooks](#pre-commit-hooks) to ensure your changes are formatted properly.
+
 Black is also supported by most editors, so you should be able to integrate it to your workflow.
+
+## Pre-commit hooks
+
+This repo uses [pre-commit](https://pre-commit.com/) for contributors to be able to quickly validate their changes.
+
+To enable this:
+
+1. Install `pre-commit` following their [installation guide](https://pre-commit.com/#install)
+2. Install the hooks for this repository:
+
+    ```sh
+    pre-commit install
+    ```
+
+You will now have sanity checks running before every commit, only on your changes.
+
+You can also run the hooks on all files with:
+
+```sh
+pre-commit run --all-files
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,16 @@ poetry run pytest
 ## Building the documentation
 
 TBD.
+
+## Code formatting
+
+This project uses [Black](https://black.readthedocs.io/en/stable/) to format its code.
+Both Python files (`*.py`) and IPython notebooks (`*.ipynb`) are reformatted.
+
+To reformat the codebase, run:
+
+```sh
+poetry run black .
+```
+
+Black is also supported by most editors, so you should be able to integrate it to your workflow.


### PR DESCRIPTION
(Cherry-picked from #1)

This adds pre-commit hooks to the repo to make it harder to commit offending code.
It also documents the black hook, as well as autoformatting in general.

@charliereese I suggest you go through the install steps here, to keep the output of `black` clean now that you merged the big autoformat PR.

Ruff hook and documentation will follow, once #10 is merged.