### PR TITLE
Add README badges for PyPI version and Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # InvestOS
 
+[![PyPI - Version](https://img.shields.io/pypi/v/investos.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.python.org/pypi/investos)
+[![PyPI - Python Versions](https://img.shields.io/pypi/pyversions/investos.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/investos/)
+
 **InvestOS** (/InvEst əʊˈes/) is a Python library for investors who want to focus on generating alpha. As it stands today, it provides reliable backtesting and portfolio optimization software for investors... but we have bigger ambitions!
 
 As mentioned in our [first blog article](https://blog.investos.io/why-we-created-investos/):


### PR DESCRIPTION
Adds a couple of basic badges to the README.

| Before | After |
| --- | --- |
| <img width="1027" alt="Screen Shot 2023-07-19 at 1 17 27 PM" src="https://github.com/charliereese/investos/assets/4542383/bc063667-67b3-4d5a-b324-45b6e9e32250"> | <img width="1031" alt="Screen Shot 2023-07-19 at 1 17 17 PM" src="https://github.com/charliereese/investos/assets/4542383/c84be5e9-1bbe-4c0b-ab0e-fc9f27405cd4"> |

Couple of benefits:

* README looks cosmetically better
* Pretty standard for popular open source projects; inspires more confidence
* Provides an easy link to the PyPI page
* We can add other badges for useful links like docs, website, license, etc. (foreshadowing 👻)